### PR TITLE
modified classname to match jsx requirements

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,8 @@ let replaceTemplateParams = (dirPath, filename) => {
 				return;
 			}
 
-			let newData = data.replace(/CLASSNAME/g, filename);
+			let className = `${filename.slice(0,1).toUpperCase()}${filename.slice(1)}`;
+			let newData = data.replace(/CLASSNAME/g, className);
 
 			fs.writeFile(`${dirPath + path.sep + filename}.js`, newData, (err) => {
 				if(err)


### PR DESCRIPTION
JSX requires that class names be capitalized, per the official [docs](https://reactjs.org/docs/jsx-in-depth.html#user-defined-components-must-be-capitalized).